### PR TITLE
Exports, arguments & test fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-preset-es2015-ie": "^6.6.1",
     "invariant": "^2.2.1",
     "jest": "^0.1.40",
+    "jest-cli": "^14.1.0",
     "key-mirror": "^1.0.1",
     "webpack": "^1.4.15"
   },

--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -1,6 +1,6 @@
 jest.dontMock('../index');
 
-var SimpleRadio = require('../index').default;
+var SimpleRadio = require('../index');
 var Radio = new SimpleRadio();
 
 describe('Radio', () => {

--- a/src/__tests__/index-test.js
+++ b/src/__tests__/index-test.js
@@ -62,9 +62,9 @@ describe('Radio', () => {
         Radio.on('test-emit', cb);
 
         // Emit
-        Radio.emit('test-emit', 'Hello');
+        Radio.emit('test-emit', 'Hello', 'World');
 
-        expect(cb).toBeCalledWith('Hello');
+        expect(cb).toBeCalledWith('Hello', 'World');
 
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ class SimpleRadio {
         storedEvent.handlers = storedEvent.handlers.filter(x => x !== cb);
     }
 
-    emit(evt: string, data: Object): void {
+    emit(evt: string): void {
         // Type and value check
         if (!evt || typeof evt !== 'string') {
             return;
@@ -65,12 +65,14 @@ class SimpleRadio {
         if (!storedEvent) {
             return;
         }
+		
+		const args = Array.prototype.slice.call(arguments, 1);
 
         // Execute each handler
-        storedEvent.handlers.forEach(cb => cb(data));
+        storedEvent.handlers.forEach(cb => cb(...args));
     }
 
-    request(req: string, data: Object): any {
+    request(req: string): any {
         // Type and value check
         if (!req || typeof req !== 'string') {
             return undefined;
@@ -84,7 +86,9 @@ class SimpleRadio {
             return undefined;
         }
 
-        return cb(data);
+		const args = Array.prototype.slice.call(arguments, 1);
+		
+        return cb(...args);
     }
 
     reply(req: string, cb: Function): void {
@@ -104,9 +108,10 @@ class SimpleRadio {
         }
 
         // Wrap callback fn to remove after first execution
-        const wrappedCb = (data) => {
+        const wrappedCb = () => {
             this.stopReplying(req);
-            return cb(data);
+			const args = Array.prototype.slice.call(arguments, 1);
+            return cb(...args);
         };
 
         this.reply(req, wrappedCb);

--- a/src/index.js
+++ b/src/index.js
@@ -134,4 +134,4 @@ class SimpleRadio {
 
 }
 
-export default SimpleRadio;
+module.exports = SimpleRadio;


### PR DESCRIPTION
#1 - Fixed by changing `export default` to `module.exports`. As the code runs through babel anyway, all ES2015 code is changed to ES5, but default exports are changed to `module.exports = { default }`, which then means it's not a straight `require()` to access the module in ES5 code. **This will be a breaking change to anyone using this module in ES5**
#2 - Changed code to take all passed arguments to the function and pass to the callback
#3 - Added missing jest-cli dependency
